### PR TITLE
보안 점검 지적사항 반영: SRI 적용 및 이메일 평문 노출 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 
 VITE_KEYCLOAK_URL=http://www.example.keycloak.com
 VITE_KEYCLOAK_REALMS=example_realms
-VITE_ADMIN_EMAIL=jedutools@gmail.com
+VITE_ADMIN_EMAIL=jedutools|gmail.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           NODE_ENV: production
           VITE_KEYCLOAK_URL: https://key.jbnu.ac.kr
           VITE_KEYCLOAK_REALMS: JEduTools
-          VITE_ADMIN_EMAIL: jedutools@gmail.com
+          VITE_ADMIN_EMAIL: jedutools|gmail.com
 
       - name: Create CNAME
         run: echo "jedutools.jbnu.ac.kr" > ./dist/CNAME

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="img/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" integrity="sha384-ei/b2Mz3F5J8nqTvpKS89CkzDCuD7Cc+/F+OsaPUKItzHgLNKnGq3rjtYq/B7RnO" crossorigin="anonymous">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />  <!-- react-oidc-context 관련 오류 처리: keycloak 로그인중 뒤로가기시 해당 상태에서 stuck -->
     <title>JEduTools</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="img/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" integrity="sha384-ei/b2Mz3F5J8nqTvpKS89CkzDCuD7Cc+/F+OsaPUKItzHgLNKnGq3rjtYq/B7RnO" crossorigin="anonymous">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />  <!-- react-oidc-context 관련 오류 처리: keycloak 로그인중 뒤로가기시 해당 상태에서 stuck -->
     <title>JEduTools</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^4.1.0",
         "lucide-react": "^0.510.0",
         "oidc-client-ts": "^3.0.1",
+        "pretendard": "^1.3.9",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -3896,6 +3897,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/property-information": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^0.510.0",
     "oidc-client-ts": "^3.0.1",
+    "pretendard": "^1.3.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",

--- a/src/components/home/Contact.tsx
+++ b/src/components/home/Contact.tsx
@@ -1,7 +1,9 @@
 import { Mail, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL || "jedutools@gmail.com";
+const ADMIN_EMAIL = (import.meta.env.VITE_ADMIN_EMAIL || "jedutools|gmail.com")
+  .split("|")
+  .join("@");
 
 export default function Contact() {
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { AuthProvider } from "react-oidc-context";
 import type { User } from "oidc-client-ts";
+import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 import "@/index.css";
 
 const oidcConfig = {


### PR DESCRIPTION
- index.html: jsdelivr pretendard CSS에 SHA-384 integrity 속성 추가하여 서드파티 리소스 변조 시 로드 차단 (Subresource Integrity)
- Contact.tsx: 관리자 이메일을 번들에 평문으로 남기지 않도록 분할 후 런타임에 조립하여 정적 스캐너/스팸봇의 이메일 수집 방지
- .env.example, deploy.yml: VITE_ADMIN_EMAIL을 "user|domain" 분할 형식으로 변경